### PR TITLE
Implementation of the ClickShape #11 event

### DIFF
--- a/BlazorSvgEditor.SvgEditor/ShapeEditors/CircleEditor.razor
+++ b/BlazorSvgEditor.SvgEditor/ShapeEditors/CircleEditor.razor
@@ -6,7 +6,7 @@
 <circle @ref=ElementReference
 
         @onpointerdown="Select"
-
+        @onclick="ClickShape"
         @onpointerenter="Enter"
         @onpointerleave="Leave"
 

--- a/BlazorSvgEditor.SvgEditor/ShapeEditors/PolygonEditor.razor
+++ b/BlazorSvgEditor.SvgEditor/ShapeEditors/PolygonEditor.razor
@@ -6,7 +6,7 @@
 <polygon @ref=ElementReference
 
          @onpointerdown="Select"
-
+         @onclick="ClickShape"
          @onpointerenter="Enter"
          @onpointerleave="Leave"
 

--- a/BlazorSvgEditor.SvgEditor/ShapeEditors/RectangleEditor.razor
+++ b/BlazorSvgEditor.SvgEditor/ShapeEditors/RectangleEditor.razor
@@ -6,7 +6,7 @@
 <rect @ref=ElementReference
       
       @onpointerdown="Select"
-      
+      @onclick="ClickShape"
       @onpointerenter="Enter"
       @onpointerleave="Leave"
 

--- a/BlazorSvgEditor.SvgEditor/ShapeEditors/ShapeEditor.cs
+++ b/BlazorSvgEditor.SvgEditor/ShapeEditors/ShapeEditor.cs
@@ -39,6 +39,11 @@ public abstract class ShapeEditor<TShape> : ComponentBase where TShape : Shape
         SvgElement.SvgEditor.SelectShape(SvgElement, eventArgs);
     }
     
+    protected void ClickShape()
+    {
+        SvgElement.SvgEditor.ClickShape.InvokeAsync(SvgElement.CustomId);
+    }
+
     protected void OnAnchorSelected(int anchorIndex)
     {
         SvgElement.SvgEditor.EditMode = EditMode.MoveAnchor;

--- a/BlazorSvgEditor.SvgEditor/ShapeEditors/ShapeEditor.cs
+++ b/BlazorSvgEditor.SvgEditor/ShapeEditors/ShapeEditor.cs
@@ -41,7 +41,7 @@ public abstract class ShapeEditor<TShape> : ComponentBase where TShape : Shape
     
     protected void ClickShape()
     {
-        SvgElement.SvgEditor.ClickShape.InvokeAsync(SvgElement.CustomId);
+        SvgElement.SvgEditor.OnShapeClicked.InvokeAsync(SvgElement.CustomId);
     }
 
     protected void OnAnchorSelected(int anchorIndex)

--- a/BlazorSvgEditor.SvgEditor/SvgEditor.Main.cs
+++ b/BlazorSvgEditor.SvgEditor/SvgEditor.Main.cs
@@ -87,9 +87,10 @@ public partial class SvgEditor
         }
     }
     [Parameter] public EventCallback<int> SelectedShapeIdChanged { get; set; }
-    
-    
-    
+    [Parameter] public EventCallback<int> ClickShape { get; set; }
+
+
+
     //Func for ImageSource Loading Task
     [Parameter] public Func<Task<(string imageSource, int width, int height)>>? ImageSourceLoadingFunc { get; set; }
     [Parameter] public RenderFragment? LoadingSpinner { get; set; }

--- a/BlazorSvgEditor.SvgEditor/SvgEditor.Main.cs
+++ b/BlazorSvgEditor.SvgEditor/SvgEditor.Main.cs
@@ -87,7 +87,7 @@ public partial class SvgEditor
         }
     }
     [Parameter] public EventCallback<int> SelectedShapeIdChanged { get; set; }
-    [Parameter] public EventCallback<int> ClickShape { get; set; }
+    [Parameter] public EventCallback<int> OnShapeClicked { get; set; }
 
 
 

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor
@@ -15,7 +15,7 @@
     <div class="o-editor">
         <SvgEditor @ref="svgEditor" CssClass="border border-gray-200 rounded-lg shadow-md" MinScale="0.8" ImageSize="(1000,750)" ImageManipulations="ImageManipulations"
                    OnShapeChanged="EditorShapeChanged" ImageSourceLoadingFunc="GetImageSource"
-                   ClickShape="ClickShape"
+                   OnShapeClicked="EditorShapeClicked"
                    @bind-SelectedShapeId="SelectedShapeId" ReadOnly="ReadOnly">
             <LoadingSpinner>
 

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor
@@ -14,7 +14,9 @@
 
     <div class="o-editor">
         <SvgEditor @ref="svgEditor" CssClass="border border-gray-200 rounded-lg shadow-md" MinScale="0.8" ImageSize="(1000,750)" ImageManipulations="ImageManipulations"
-                   OnShapeChanged="EditorShapeChanged" ImageSourceLoadingFunc="GetImageSource" @bind-SelectedShapeId="SelectedShapeId" ReadOnly="false">
+                   OnShapeChanged="EditorShapeChanged" ImageSourceLoadingFunc="GetImageSource"
+                   ClickShape="ClickShape"
+                   @bind-SelectedShapeId="SelectedShapeId" ReadOnly="true">
             <LoadingSpinner>
 
                 <div class="flex items-center justify-center h-full">
@@ -62,6 +64,7 @@
                 <div class="inline-flex mt-2" role="group">
                     <button @onclick="ResetTransform" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-yellow-400 hover:bg-yellow-500 focus:ring-4 focus:ring-yellow-300 font-medium rounded-lg text-sm px-5 py-2 mr-2">Reset Transformation</button>
                     <button @onclick="ClearAll" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2">Clear</button>
+                    <button @onclick="@(()=> ReadOnly=!ReadOnly)" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-green-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2">@(ReadOnly? "Read Only":"Editable")</button>
                 </div>
             </div>
 
@@ -123,7 +126,7 @@
 
                 @foreach (var shape in Shapes)
                 {
-                    <div @onclick="() => ShapeSelected(shape.CustomId)" class="cursor-pointer border border-gray-300 p-1.5 inline-flex rounded-lg mb-2 @(shape.CustomId == SelectedShapeId ? "border-red-900 bg-red-300" : "")">
+                    <div @onclick="() => ShapeSelected(shape.CustomId)" class="cursor-pointer border border-gray-300 p-1.5 inline-flex rounded-lg mb-2 @(((shape.CustomId == SelectedShapeId) || (shape.CustomId == ClickedShapeId))  ? "border-red-900 bg-red-300" : "")">
                         <b class="mr-2">@(shape.ShapeType.ToString()):</b>
                         <p>(Id: @shape.CustomId)</p>
                     </div>

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor
@@ -16,7 +16,7 @@
         <SvgEditor @ref="svgEditor" CssClass="border border-gray-200 rounded-lg shadow-md" MinScale="0.8" ImageSize="(1000,750)" ImageManipulations="ImageManipulations"
                    OnShapeChanged="EditorShapeChanged" ImageSourceLoadingFunc="GetImageSource"
                    ClickShape="ClickShape"
-                   @bind-SelectedShapeId="SelectedShapeId" ReadOnly="true">
+                   @bind-SelectedShapeId="SelectedShapeId" ReadOnly="ReadOnly">
             <LoadingSpinner>
 
                 <div class="flex items-center justify-center h-full">
@@ -63,8 +63,8 @@
 
                 <div class="inline-flex mt-2" role="group">
                     <button @onclick="ResetTransform" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-yellow-400 hover:bg-yellow-500 focus:ring-4 focus:ring-yellow-300 font-medium rounded-lg text-sm px-5 py-2 mr-2">Reset Transformation</button>
-                    <button @onclick="ClearAll" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2">Clear</button>
-                    <button @onclick="@(()=> ReadOnly=!ReadOnly)" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-green-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2">@(ReadOnly? "Read Only":"Editable")</button>
+                    <button @onclick="ClearAll" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2 mr-2">Clear</button>
+                    <button @onclick="@(()=> ReadOnly=!ReadOnly)" type="button" class="shadow-sm flex-grow focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2">@(ReadOnly? "Read Only":"Editable")</button>
                 </div>
             </div>
 

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
@@ -9,9 +9,10 @@ public partial class Preview
 {
     private SvgEditor? svgEditor;
     private int SelectedShapeId { get; set; }
+    private int ClickedShapeId { get; set; }    
+    private bool ReadOnly { get; set; } = false; //Is the editor read only?
 
-
-    //
+    
     private List<Shape> Shapes = new();
     string status = "--Status--";
 
@@ -111,5 +112,10 @@ public partial class Preview
     private void DeleteShape()
     {
         svgEditor?.RemoveSelectedShape();
+    }
+
+    void ClickShape(int CustomId)
+    {
+        ClickedShapeId = CustomId;
     }
 }

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
@@ -10,7 +10,7 @@ public partial class Preview
     private SvgEditor? svgEditor;
     private int SelectedShapeId { get; set; }
     private int ClickedShapeId { get; set; }    
-    private bool ReadOnly { get; set; } = false; //Is the editor read only?
+    private bool ReadOnly { get; set; } = false; 
 
     
     private List<Shape> Shapes = new();

--- a/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
+++ b/BlazorSvgEditor.WasmTest/Pages/Preview.razor.cs
@@ -114,7 +114,7 @@ public partial class Preview
         svgEditor?.RemoveSelectedShape();
     }
 
-    void ClickShape(int CustomId)
+    void EditorShapeClicked(int CustomId)
     {
         ClickedShapeId = CustomId;
     }


### PR DESCRIPTION
Implementation of the ClickShape #11 event to receive click events on a shape regardless of the state of the ReadOnly property.

The example page has been modified to show the new behavior